### PR TITLE
add nixos service

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, config, inputs, ... }:
+{ lib, pkgs, config, ... }:
 with lib;
 
 let cfg = config.services.s3photoalbum;
@@ -58,6 +58,14 @@ in {
           User = cfg.user;
           Group = cfg.group;
           WorkingDirectory = cfg.dataDir;
+          ExecStart = "${pkgs.s3photoalbum}/bin/server";
+          Restart = "on-failure";
+        }
+        (mkIf (cfg.dataDir == "/var/lib/s3photoalbum") {
+          StateDirectory = "s3photoalbum";
+        })
+      ];
+    };
           ExecStart = "${pkgs.s3photoalbum}/bin/s3photoalbum";
           Restart = "on-failure";
         }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,84 @@
+{ lib, pkgs, config, inputs, ... }:
+with lib;
+
+let cfg = config.services.s3photoalbum;
+in {
+
+  options.services.s3photoalbum = {
+
+    enable = mkEnableOption "s3photoalbum";
+
+    dataDir = mkOption {
+      type = types.str;
+      default = "/var/lib/s3photoalbum";
+      description = ''
+        The directory where s3photoalbum stores its data files.
+      '';
+    };
+
+    envfile = mkOption {
+      type = types.str;
+      default = "/var/src/secrets/s3photoalbum/envfile";
+      description = ''
+        The location of the envfile containing secrets
+      '';
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Open the appropriate ports in the firewall for s3photoalbum.
+      '';
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "s3photoalbum";
+      description = "User account under which s3photoalbum runs.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "s3photoalbum";
+      description = "Group under which s3photoalbum runs.";
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.services.s3photoalbum = {
+      description = "A self-hosted photo album";
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = mkMerge [
+        {
+          EnvironmentFile = [ cfg.envfile ];
+          User = cfg.user;
+          Group = cfg.group;
+          WorkingDirectory = cfg.dataDir;
+          ExecStart = "${pkgs.s3photoalbum}/bin/s3photoalbum";
+          Restart = "on-failure";
+        }
+        (mkIf (cfg.dataDir == "/var/lib/s3photoalbum") {
+          StateDirectory = "s3photoalbum";
+        })
+      ];
+    };
+
+    users.users = mkIf (cfg.user == "s3photoalbum") {
+      s3photoalbum = {
+        isSystemUser = true;
+        group = cfg.group;
+        description = "s3photoalbum system user";
+      };
+    };
+
+    users.groups = mkIf (cfg.group == "s3photoalbum") { s3photoalbum = { }; };
+
+    networking.firewall = mkIf cfg.openFirewall { allowedTCPPorts = [ 8083 ]; };
+
+  };
+  meta = { maintainers = with lib.maintainers; [ mayniklas ]; };
+}

--- a/default.nix
+++ b/default.nix
@@ -96,7 +96,7 @@ in {
 
     users.groups = mkIf (cfg.group == "s3photoalbum") { s3photoalbum = { }; };
 
-    networking.firewall = mkIf cfg.openFirewall { allowedTCPPorts = [ 8083 ]; };
+    networking.firewall = mkIf cfg.openFirewall { allowedTCPPorts = [ 7788 ]; };
 
   };
   meta = { maintainers = with lib.maintainers; [ mayniklas ]; };

--- a/default.nix
+++ b/default.nix
@@ -66,7 +66,18 @@ in {
         })
       ];
     };
-          ExecStart = "${pkgs.s3photoalbum}/bin/s3photoalbum";
+
+    systemd.services.s3photoalbum-thumbnailer = {
+      description = "A self-hosted photo album - thumbnailer service";
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = mkMerge [
+        {
+          EnvironmentFile = [ cfg.envfile ];
+          User = cfg.user;
+          Group = cfg.group;
+          WorkingDirectory = cfg.dataDir;
+          ExecStart = "${pkgs.s3photoalbum}/bin/thumbnailer";
           Restart = "on-failure";
         }
         (mkIf (cfg.dataDir == "/var/lib/s3photoalbum") {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
             version = "0.1";
 
             src = ./.;
-            vendorSha256 = "sha256-1cgqoLbZzKBVUsaW0ssYBt0gqtuCYgMatREan1fJEbY=";
+            vendorSha256 = "sha256-HcPUWpPpiwBf3wUHu1Mh6Jk3FfMtsoLhXXg0RoABUno=";
             subPackages = [ "cmd/server" "cmd/thumbnailer" ];
             installPhase = ''
               mkdir -p $out

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,16 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { self, nixpkgs, flake-utils }:
+
+    {
+      nixosModule = ({ pkgs, ... }: {
+        imports = [ ./default.nix ];
+        nixpkgs.overlays =
+          [ (_self: _super: { s3photoalbum = self.packages.${pkgs.system}; }) ];
+      });
+
+    } //
+
     flake-utils.lib.eachDefaultSystem (system:
       with nixpkgs.legacyPackages.${system}; rec {
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
       nixosModule = ({ pkgs, ... }: {
         imports = [ ./default.nix ];
         nixpkgs.overlays =
-          [ (_self: _super: { s3photoalbum = self.packages.${pkgs.system}; }) ];
+          [ (_self: _super: { s3photoalbum = self.packages.${pkgs.system}.s3photoalbum; }) ];
       });
 
     } //


### PR DESCRIPTION
Service is in a working state:
```nix
services.s3photoalbum = { enable = true; };
```
Make sure the envfile exists: `/var/src/secrets/s3photoalbum/envfile`
Currently, the template folder needs to be manually created in the `dataDir` (by default: `/var/lib/s3photoalbum`) with the correct permissions.
To configure nginx:
```nix
services.s3photoalbum = {
  enable = true;
  hostname = "gallery.your-domain.com";
  acme = true;
  nginx = true;
};
```